### PR TITLE
Add synapse-car-plugin info to pom.xml

### DIFF
--- a/esb-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/esb-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -30,6 +30,15 @@
                 <updatePolicy>daily</updatePolicy>
                 <checksumPolicy>ignore</checksumPolicy>
             </releases>
+            <id>wso2-nexus-releases</id>
+            <url>https://maven.wso2.org/nexus/content/repositories/releases/</url>
+        </repository>
+        <repository>
+            <releases>
+                <enabled>true</enabled>
+                <updatePolicy>daily</updatePolicy>
+                <checksumPolicy>ignore</checksumPolicy>
+            </releases>
             <id>wso2-nexus</id>
             <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
         </repository>
@@ -42,29 +51,24 @@
             <url>https://repo.maven.apache.org/maven2</url>
         </repository>
     </repositories>
-    <pluginRepositories>
-        <pluginRepository>
-            <releases>
-                <enabled>true</enabled>
-                <updatePolicy>daily</updatePolicy>
-                <checksumPolicy>ignore</checksumPolicy>
-            </releases>
-            <id>wso2-nexus</id>
-            <url>https://maven.wso2.org/nexus/content/groups/wso2-public/</url>
-        </pluginRepository>
-        <pluginRepository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>central</id>
-            <name>Central Repository</name>
-            <url>https://repo.maven.apache.org/maven2</url>
-        </pluginRepository>
-    </pluginRepositories>
 
     <build>
         <directory>target/capp</directory>
         <plugins>
+            <plugin>
+                <groupId>org.wso2.maven</groupId>
+                <artifactId>synapse-car-plugin</artifactId>
+                <version>1.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>car</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration />
+            </plugin>
         </plugins>
     </build>
     <reporting>


### PR DESCRIPTION
## Goals
> Synapse-CAR-plugin is added to the archetype which generates the deployable archive (.car) file when wso2-esb-project gets built.
