### PR TITLE
Update the esb-project-archetype's pom.xml file to add resource filtering capability

### DIFF
--- a/esb-project-archetype/src/main/resources/archetype-resources/pom.xml
+++ b/esb-project-archetype/src/main/resources/archetype-resources/pom.xml
@@ -60,14 +60,21 @@
     </pluginRepositories>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.wso2.maven</groupId>
                 <artifactId>vscode-car-plugin</artifactId>
-                <version>5.2.22</version>
+                <version>5.2.29</version>
                 <extensions>true</extensions>
                 <configuration>
-                    <archiveLocation>${project.basedir}/target/capp</archiveLocation>
+                    <!-- enable this to re define an archive location other than the default location
+                    <archiveLocation>${project.basedir}/target/capp</archiveLocation-->
                     <!-- enable this to rename the .car file name
                     <archiveName>archive_name</archiveName-->
                     <!-- enable this to rename the carbon application name


### PR DESCRIPTION
## Purpose
- Add resources element to pom to introduce resource filtering capability
- Commented out the archiveLocation configuration to make the default archive location as the project.build.directory, which is the target folder.

## Related PRs
https://github.com/wso2/maven-tools/pull/71

