### PR TITLE
Revert "Direct the issue creation to product-is"

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,0 @@
-blank_issues_enabled: false
-contact_links:
-  - name: Report an issue
-    url: https://github.com/wso2/product-is/issues/new/choose
-    about: Issue creation for this component is done in the product-is repo. Click "Open" to continue.


### PR DESCRIPTION
Reverts wso2-extensions/archetypes#29

This is not a repo owned by the IAM team only